### PR TITLE
Add activation and profile tools

### DIFF
--- a/template-mcp-server/src/core/tools.ts
+++ b/template-mcp-server/src/core/tools.ts
@@ -81,4 +81,79 @@ export function registerTools(server: FastMCP) {
       };
     }
   });
+
+  // Activate a customer account
+  server.addTool({
+    name: "activate_account",
+    description: "Activates a customer's account by email",
+    parameters: z.object({
+      email: z.string().email().describe("Customer email to activate")
+    }),
+    execute: async ({ email }) => {
+      const url = `https://expatelitesingles.com/api/sirri_api/activate/${email}`;
+      const response = await fetch(url, { method: "GET" });
+      const data = await response.json();
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(data)
+          }
+        ]
+      };
+    }
+  });
+
+  // Delegate automatic messaging tasks
+  server.addTool({
+    name: "delegate_auto_messages",
+    description: "Delegates messaging tasks for a user by email",
+    parameters: z.object({
+      email: z.string().email().describe("Customer email for scheduling messages")
+    }),
+    execute: async ({ email }) => {
+      const response = await fetch(
+        "https://expatelitesingles.com/api/sirri_api/auto_messages_email",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/x-www-form-urlencoded" },
+          body: `EMAIL=`+email
+        }
+      );
+      const data = await response.json();
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(data)
+          }
+        ]
+      };
+    }
+  });
+
+  // Check if a user has uploaded a profile picture
+  server.addTool({
+    name: "has_profile_picture",
+    description: "Checks whether the specified user has a profile picture",
+    parameters: z.object({
+      email: z.string().email().describe("Customer email")
+    }),
+    execute: async ({ email }) => {
+      const url = `https://expatelitesingles.com/api/has_picture?EMAIL=${email}`;
+      const response = await fetch(url);
+      const data = await response.json();
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(data)
+          }
+        ]
+      };
+    }
+  });
 }


### PR DESCRIPTION
## Summary
- extend mcp server tools
  - add `activate_account`
  - add `delegate_auto_messages`
  - add `has_profile_picture`
- send raw email strings instead of using `encodeURIComponent`

## Testing
- `npm install` *(fails: network access blocked)*
- `bun run build` *(fails: Could not resolve fastmcp)*

------
https://chatgpt.com/codex/tasks/task_e_6880bc551b3883238f60c88542345b5a