### PR TITLE
Add optional package parameter to activate tool

### DIFF
--- a/template-mcp-server/src/core/tools.ts
+++ b/template-mcp-server/src/core/tools.ts
@@ -87,10 +87,12 @@ export function registerTools(server: FastMCP) {
     name: "activate_account",
     description: "Activates a customer's account by email",
     parameters: z.object({
-      email: z.string().email().describe("Customer email to activate")
+      email: z.string().email().describe("Customer email to activate"),
+      package: z.string().optional().describe("Optional package to apply")
     }),
-    execute: async ({ email }) => {
-      const url = `https://expatelitesingles.com/api/sirri_api/activate/${email}`;
+    execute: async ({ email, package: pkg }) => {
+      const query = pkg ? `?package=${encodeURIComponent(pkg)}` : "";
+      const url = `https://expatelitesingles.com/api/sirri_api/activate/${email}${query}`;
       const response = await fetch(url, { method: "GET" });
       const data = await response.json();
 


### PR DESCRIPTION
## Summary
- include optional `package` parameter for `activate_account` tool
- append parameter in request as query string when provided

## Testing
- `npm run build` *(fails: Could not resolve fastmcp)*

------
https://chatgpt.com/codex/tasks/task_e_6880f5950c3c83238ec471a263b9ec9c