### PR TITLE
Add one-off reminder support to schema, CLI and runtime

### DIFF
--- a/reminder_service.py
+++ b/reminder_service.py
@@ -28,6 +28,7 @@ def check_reminders():
     current_date_str = now.strftime("%Y-%m-%d")
     current_day_of_week = now.weekday() # Monday is 0 and Sunday is 6
     reminder_triggered = False
+    reminders_to_remove = []
 
     for reminder in reminders:
         reminder_time_str = reminder['time']
@@ -39,6 +40,7 @@ def check_reminders():
         pre_command = reminder.get('pre_command')
         post_command = reminder.get('post_command')
         no_notif = reminder.get('skip_notification', False)
+        one_off = reminder.get('one_off', False)
 
         # Check if the reminder should be triggered based on the day of the week
         if allowed_days and current_day_of_week not in allowed_days:
@@ -88,7 +90,9 @@ def check_reminders():
                 if returncode == 0: # Acknowledged
                     logging.info(f"Reminder for {reminder['file']} acknowledged.")
                     reminder['last_triggered'] = current_date_str
-                    save_reminders(reminders)
+
+                    if one_off:
+                        reminders_to_remove.append(reminder)
 
                     if post_command:
                         logging.info(f"Executing post-command: {post_command}")
@@ -122,6 +126,11 @@ def check_reminders():
                 logging.error(f"Error: Reminder file not found: {reminder['file']}")
             except Exception as e:
                 logging.exception(f"An unexpected error occurred: {e}")
+
+    if reminders_to_remove:
+        reminders = [reminder for reminder in reminders if reminder not in reminders_to_remove]
+
+    save_reminders(reminders)
     
     if not reminder_triggered:
         logging.info("No reminders to launch at this time.")

--- a/reminders.json
+++ b/reminders.json
@@ -12,7 +12,8 @@
         "start_date": "2025-11-01",
         "pre_command": null,
         "post_command": null,
-        "label": "Weekend"
+        "label": "Weekend",
+        "one_off": false
     },
     {
         "time": "06:00",
@@ -32,7 +33,8 @@
         "start_date": "2025-11-01",
         "pre_command": null,
         "post_command": "/home/mehmet/miniconda3/envs/idris/bin/python /home/mehmet/Proyectos/TANZIMAT/scripts/dailyshadowwork.py",
-        "label": "Journal"
+        "label": "Journal",
+        "one_off": false
     },
     {
         "time": "06:00",
@@ -53,7 +55,8 @@
         "pre_command": null,
         "post_command": "/home/mehmet/miniconda3/envs/idris/bin/python /home/mehmet/Proyectos/TANZIMAT/scripts/sendsbillsauto.py",
         "label": "Bills",
-        "skip_notification": "true"
+        "skip_notification": "true",
+        "one_off": false
     },
     {
         "time": "06:00",
@@ -73,7 +76,8 @@
         "start_date": "2025-11-01",
         "pre_command": null,
         "post_command": "/home/mehmet/miniconda3/envs/idris/bin/python /home/mehmet/Proyectos/TANZIMAT/scripts/spend_recorder.py",
-        "label": "Recording daily spend"
+        "label": "Recording daily spend",
+        "one_off": false
     },
     {
         "time": "04:00",
@@ -93,7 +97,8 @@
         "start_date": "2025-11-01",
         "pre_command": null,
         "post_command": "/home/mehmet/miniconda3/envs/idris/bin/python /home/mehmet/Proyectos/TANZIMAT/scripts/add_prayer_reminders.py",
-        "label": "Added the timings for salah"
+        "label": "Added the timings for salah",
+        "one_off": false
     },
     {
         "time": "20:30",
@@ -113,7 +118,8 @@
         "start_date": "2025-11-01",
         "pre_command": null,
         "post_command": "/home/mehmet/miniconda3/envs/idris/bin/python /home/mehmet/Proyectos/TANZIMAT/scripts/remove_prayer_reminders.py",
-        "label": "Removed the timings for salah"
+        "label": "Removed the timings for salah",
+        "one_off": false
     },
     {
         "time": "20:30",
@@ -132,7 +138,8 @@
         "start_date": "2025-11-01",
         "pre_command": null,
         "post_command": "/home/mehmet/miniconda3/envs/idris/bin/python /home/mehmet/Proyectos/TANZIMAT/scripts/post_workout_log.py",
-        "label": "Workout"
+        "label": "Workout",
+        "one_off": false
     },
     {
         "time": "20:30",
@@ -152,7 +159,8 @@
         "start_date": "2025-11-01",
         "pre_command": null,
         "post_command": "/home/mehmet/miniconda3/envs/idris/bin/python /home/mehmet/Proyectos/TANZIMAT/scripts/daily_reflection.py",
-        "label": "Daily reflection"
+        "label": "Daily reflection",
+        "one_off": false
     },
     {
         "time": "20:30",
@@ -166,7 +174,8 @@
         "start_date": "2025-11-01",
         "pre_command": null,
         "post_command": "/home/mehmet/miniconda3/envs/idris/bin/python /home/mehmet/Proyectos/TANZIMAT/scripts/weekly_review.py",
-        "label": "Weekly reflection"
+        "label": "Weekly reflection",
+        "one_off": false
     },
     {
         "time": "20:30",
@@ -180,7 +189,8 @@
         "start_date": "2025-11-01",
         "pre_command": null,
         "post_command": "/home/mehmet/miniconda3/envs/idris/bin/python /home/mehmet/Proyectos/TANZIMAT/scripts/monthly_checkin.py",
-        "label": "Monthly reflection"
+        "label": "Monthly reflection",
+        "one_off": false
     },
     {
         "time": "20:30",
@@ -200,7 +210,8 @@
         "start_date": "2025-11-01",
         "pre_command": null,
         "post_command": "",
-        "label": "Comms reminder"
+        "label": "Comms reminder",
+        "one_off": false
     },
     {
         "time": "06:00",
@@ -212,7 +223,8 @@
         "start_date": "2025-11-01",
         "pre_command": "",
         "post_command": "notify-send \"Make sure to get it done\"",
-        "label": "Meta Ads Manager"
+        "label": "Meta Ads Manager",
+        "one_off": false
     },
     {
         "time": "20:30",
@@ -224,7 +236,8 @@
         "repeat_days": null,
         "start_date": null,
         "pre_command": null,
-        "post_command": null
+        "post_command": null,
+        "one_off": false
     },
     {
         "time": "05:00",
@@ -236,7 +249,8 @@
         "repeat_days": null,
         "start_date": null,
         "pre_command": null,
-        "post_command": null
+        "post_command": null,
+        "one_off": false
     },
     {
         "time": "19:30",
@@ -248,7 +262,8 @@
         "repeat_days": null,
         "start_date": null,
         "pre_command": null,
-        "post_command": null
+        "post_command": null,
+        "one_off": false
     },
     {
         "time": "06:00",
@@ -263,7 +278,8 @@
         "repeat_days": null,
         "start_date": null,
         "pre_command": null,
-        "post_command": null
+        "post_command": null,
+        "one_off": false
     },
     {
         "time": "05:29",
@@ -283,7 +299,8 @@
         "repeat_days": null,
         "start_date": null,
         "pre_command": null,
-        "post_command": "/home/mehmet/miniconda3/envs/idris/bin/python /home/mehmet/Proyectos/TANZIMAT/scripts/recite_surah.py"
+        "post_command": "/home/mehmet/miniconda3/envs/idris/bin/python /home/mehmet/Proyectos/TANZIMAT/scripts/recite_surah.py",
+        "one_off": false
     },
     {
         "time": "12:30",
@@ -303,7 +320,8 @@
         "repeat_days": null,
         "start_date": null,
         "pre_command": null,
-        "post_command": "/home/mehmet/miniconda3/envs/idris/bin/python /home/mehmet/Proyectos/TANZIMAT/scripts/recite_surah.py"
+        "post_command": "/home/mehmet/miniconda3/envs/idris/bin/python /home/mehmet/Proyectos/TANZIMAT/scripts/recite_surah.py",
+        "one_off": false
     },
     {
         "time": "15:39",
@@ -323,7 +341,8 @@
         "repeat_days": null,
         "start_date": null,
         "pre_command": null,
-        "post_command": "/home/mehmet/miniconda3/envs/idris/bin/python /home/mehmet/Proyectos/TANZIMAT/scripts/recite_surah.py"
+        "post_command": "/home/mehmet/miniconda3/envs/idris/bin/python /home/mehmet/Proyectos/TANZIMAT/scripts/recite_surah.py",
+        "one_off": false
     },
     {
         "time": "18:34",
@@ -343,7 +362,8 @@
         "repeat_days": null,
         "start_date": null,
         "pre_command": null,
-        "post_command": "/home/mehmet/miniconda3/envs/idris/bin/python /home/mehmet/Proyectos/TANZIMAT/scripts/recite_surah.py"
+        "post_command": "/home/mehmet/miniconda3/envs/idris/bin/python /home/mehmet/Proyectos/TANZIMAT/scripts/recite_surah.py",
+        "one_off": false
     },
     {
         "time": "19:31",
@@ -363,7 +383,8 @@
         "repeat_days": null,
         "start_date": null,
         "pre_command": null,
-        "post_command": "/home/mehmet/miniconda3/envs/idris/bin/python /home/mehmet/Proyectos/TANZIMAT/scripts/recite_surah.py"
+        "post_command": "/home/mehmet/miniconda3/envs/idris/bin/python /home/mehmet/Proyectos/TANZIMAT/scripts/recite_surah.py",
+        "one_off": false
     },
     {
         "time": "13:30",
@@ -375,7 +396,8 @@
         "repeat_days": null,
         "start_date": null,
         "pre_command": null,
-        "post_command": null
+        "post_command": null,
+        "one_off": false
     },
     {
         "time": "22:30",
@@ -387,6 +409,7 @@
         "repeat_days": null,
         "start_date": null,
         "pre_command": null,
-        "post_command": null
+        "post_command": null,
+        "one_off": false
     }
 ]

--- a/reminders_template.json
+++ b/reminders_template.json
@@ -1,13 +1,14 @@
 [
-  {
-    "time": "09:00",
-    "file": "/home/mehmet/Proyectos/TANZIMAT/reminder_file.md",
-    "last_triggered": null,
-    "days": null,
-    "days_of_month": null,
-    "repeat_days": null,
-    "start_date": null,
-    "pre_command": null,
-    "post_command": null
-  }
+    {
+        "time": "09:00",
+        "file": "/home/mehmet/Proyectos/TANZIMAT/reminder_file.md",
+        "last_triggered": null,
+        "days": null,
+        "days_of_month": null,
+        "repeat_days": null,
+        "start_date": null,
+        "pre_command": null,
+        "post_command": null,
+        "one_off": false
+    }
 ]

--- a/scripts/add_reminder.py
+++ b/scripts/add_reminder.py
@@ -43,7 +43,8 @@ def add_reminder(args):
         "repeat_days": args.repeat_days,
         "start_date": args.start_date,
         "pre_command": args.pre_command,
-        "post_command": args.post_command
+        "post_command": args.post_command,
+        "one_off": args.one_off
     }
 
     # Remove any existing reminder with the same label (new one wins)
@@ -70,6 +71,7 @@ if __name__ == "__main__":
     parser.add_argument("--start-date", help="Start date for repeating reminders (YYYY-MM-DD).")
     parser.add_argument("--pre-command", help="Command to execute before the reminder.")
     parser.add_argument("--post-command", help="Command to execute after the reminder.")
+    parser.add_argument("--one-off", action="store_true", help="Remove reminder after acknowledged display.")
 
     args = parser.parse_args()
 


### PR DESCRIPTION
### Motivation
- Allow reminders that should be removed after a single acknowledged display (one-off reminders) by adding an explicit boolean field to the reminder schema and supporting CLI/runtime behavior.
- Keep backward compatibility so existing reminder files work without modification by treating the field as optional with a default of `false`.

### Description
- Added a `--one-off` CLI flag to `scripts/add_reminder.py` and included `

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8172601e0832388772dc2e1486610)