### PR TITLE
Add one-off selection to rofi reminder script

### DIFF
--- a/scripts/rofi_add_reminder.sh
+++ b/scripts/rofi_add_reminder.sh
@@ -23,6 +23,12 @@ if [ -z "$LABEL" ]; then
     exit 1
 fi
 
+# Prompt for one-off reminder status
+ONE_OFF_RESPONSE=$(printf "yes\nno" | rofi -dmenu -i -p "One-off reminder? (yes/no)")
+if [ -z "$ONE_OFF_RESPONSE" ]; then
+    exit 1
+fi
+
 # Create a unique filename for the reminder content
 # Using label and current timestamp for uniqueness
 FILENAME="${LABEL// /_}" # Replace spaces in label with underscores
@@ -34,7 +40,22 @@ FULL_FILE_PATH="$REMINDER_CONTENT_DIR/$FILENAME"
 echo "$REMINDER_MESSAGE" > "$FULL_FILE_PATH"
 
 # Call add_reminder.py with the new file path
-/home/mehmet/miniconda3/envs/idris/bin/python /home/mehmet/Proyectos/TANZIMAT/scripts/add_reminder.py --time "$TIME" --file "$FULL_FILE_PATH" --label "$LABEL"
+ADD_REMINDER_CMD=(
+    /home/mehmet/miniconda3/envs/idris/bin/python
+    /home/mehmet/Proyectos/TANZIMAT/scripts/add_reminder.py
+    --time "$TIME"
+    --file "$FULL_FILE_PATH"
+    --label "$LABEL"
+)
 
-notify-send "Reminder Added" "Reminder with label '$LABEL' has been added. Content saved to: $FULL_FILE_PATH"
+if [ "$ONE_OFF_RESPONSE" = "yes" ]; then
+    ADD_REMINDER_CMD+=(--one-off)
+fi
 
+"${ADD_REMINDER_CMD[@]}"
+
+if [ "$ONE_OFF_RESPONSE" = "yes" ]; then
+    notify-send "Reminder Added" "One-off reminder with label '$LABEL' has been added. Content saved to: $FULL_FILE_PATH"
+else
+    notify-send "Reminder Added" "Reminder with label '$LABEL' has been added. Content saved to: $FULL_FILE_PATH"
+fi


### PR DESCRIPTION
### Motivation
- Provide an explicit `One-off reminder? (yes/no)` prompt so callers can choose to create one-off reminders from the rofi flow.
- Preserve the existing behavior and flags (`--time`, `--file`, `--label`) while enabling the optional `--one-off` behavior.
- Make the desktop notification clearly indicate when a created reminder is one-off.

### Description
- Add a rofi yes/no prompt and store the result in `ONE_OFF_RESPONSE` with exit-on-empty handling.
- Build the Python invocation as an `ADD_REMINDER_CMD` array that includes `--time`, `--file`, and `--label` and conditionally appends `--one-off` when `ONE_OFF_RESPONSE` is `yes`.
- Execute the assembled command with `"${ADD_REMINDER_CMD[@]}"` and update the `notify-send` message to state `One-off reminder` when appropriate.

### Testing
- Ran `bash -n scripts/rofi_add_reminder.sh` to validate shell syntax and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a820e264908323a9afe3bb70f5c108)